### PR TITLE
ES 6 docs: better testing

### DIFF
--- a/.docker/dockerfile-arch
+++ b/.docker/dockerfile-arch
@@ -1,6 +1,6 @@
 FROM archlinux/base
 
-RUN pacman -Sy --noconfirm \
+RUN pacman -Sqy --noconfirm \
 	python2-setuptools \
 	# setuptools unspecified dependencies: https://bugs.archlinux.org/task/56493?project=0&order=id&sort=desc&string=python2-virtualenv
 	python2-virtualenv \
@@ -18,12 +18,7 @@ ADD . ${LIBREANT_INST_DIR}/
 # Install libreant
 WORKDIR $LIBREANT_INST_DIR
 RUN virtualenv2 -p /usr/bin/python2 ve
-RUN ./ve/bin/pip install .
-
-### AFTER LIBREANT 0.6 ###
-#  
-# RUN virtualenv -p /usr/bin/python2 ve
-# RUN ./ve/bin/pip install libreant
+RUN ./ve/bin/pip -q install .
 
 EXPOSE 5000
 

--- a/.docker/dockerfile-debian-stable
+++ b/.docker/dockerfile-debian-stable
@@ -1,7 +1,7 @@
 FROM debian:stable
 # we cannot use the slimmified version of debian stable because of this bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -q update && apt-get install -qy --no-install-recommends \
 		apt-transport-https \
 		curl \
 		gnupg \
@@ -12,14 +12,14 @@ RUN curl --silent --show-error "https://artifacts.elastic.co/GPG-KEY-elasticsear
 
 RUN echo "deb https://artifacts.elastic.co/packages/6.x/apt stable main" > /etc/apt/sources.list.d/elastic-6.x.list
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -q update && apt-get -q install -y --no-install-recommends \
 		openjdk-8-jre-headless \
 		procps \
 		# the ps command is required by elasticsearch startup script
 		elasticsearch
 
 # Install the base system requirements: python, pip
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -q update && apt-get install -qy --no-install-recommends \
 		python2.7 \
 		python-wheel \
 		virtualenv \
@@ -40,4 +40,4 @@ RUN ./ve/bin/pip install .
 EXPOSE 5000
 
 # we bypass systemd to run elasticsearch
-CMD service elasticsearch start && ./ve/bin/libreant
+CMD bash /libreant/.docker/inside-runlibreant

--- a/.docker/dockerfile-ubuntu-lts
+++ b/.docker/dockerfile-ubuntu-lts
@@ -1,6 +1,8 @@
 FROM ubuntu:latest
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# we cannot use the slimmified version of debian stable because of this bug https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199
+
+RUN apt-get -q update && apt-get install -qy --no-install-recommends \
 		apt-transport-https \
 		curl \
 		gnupg \
@@ -17,8 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		# the ps command is required by elasticsearch startup script
 		elasticsearch
 
+
 # Install the base system requirements: python, pip
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get -q update && apt-get install -qy --no-install-recommends \
 		python2.7 \
 		python-wheel \
 		virtualenv \
@@ -34,9 +37,14 @@ ADD . ${LIBREANT_INST_DIR}/
 # Install libreant
 WORKDIR $LIBREANT_INST_DIR
 RUN virtualenv -p /usr/bin/python2.7 ve
-RUN ./ve/bin/pip install .
+RUN ./ve/bin/pip -q install .
+
+### AFTER LIBREANT 0.6 ###
+#  
+# RUN virtualenv -p /usr/bin/python2.7 ve
+# RUN ./ve/bin/pip install libreant
 
 EXPOSE 5000
 
 # we bypass systemd to run elasticsearch
-CMD service elasticsearch start && ./ve/bin/libreant
+CMD bash /libreant/.docker/inside-runlibreant

--- a/.docker/inside-runlibreant
+++ b/.docker/inside-runlibreant
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eux
+service elasticsearch start
+for i in {1..4}; do  # wait until elasticsearch is ready
+    curl 'http://localhost:9200/' -s && break
+    sleep $i
+done
+curl '-s' "http://localhost:9200/_cluster/health/index_name?wait_for_status=green&timeout=20s"
+./ve/bin/libreant

--- a/.docker/inside-runtests
+++ b/.docker/inside-runtests
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+service elasticsearch start
+curl "http://localhost:9200/_cluster/health/index_name?wait_for_status=green&timeout=20s"
+cd "${LIBREANT_INST_DIR}"
+./ve/bin/python setup.py test
+

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
-.docker/
+.docker/dockerfile*
+.docker/test*
 .git/
 *.swp
 *.pyc

--- a/webant/webant.py
+++ b/webant/webant.py
@@ -135,7 +135,7 @@ def create_app(conf={}):
             books.append(src)
         format = requestedFormat(request,
                                  ['text/html',
-                                  'text/xml', 'application/rss+xml', 'opensearch'])
+                                  'text/xml', 'application/rss+xml'])
         if (not format) or (format is 'text/html'):
             return render_template('search.html',
                                    books=books,


### PR DESCRIPTION
testing script has been improved:
* less verbose package manager output
* backoff improved to linear (less outputs, more "progressive" timeout increase)
* test error/success has better output
* before testing `/search`, home (`/`) is tested

But the main improvement is the usage of `_cluster/health/index_name?wait_for_status=green&timeout=20s` which makes libreant start only when elasticsearch is actually ready, without resorting to ugly sleeps.

However, this doesn't remove the need for backoffs: we still need to wait until everything is ready, as docker isn't great about distinguishing between "process started" and "process ready".